### PR TITLE
Removed passport from authentication. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .idea/
 .vscode/
 *.orig
+config.js

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-##########################
-#REACT_USER_AUTH_TUTORIAL#
-##########################
+React User Authentication Tutorial
+==================================
 
-*INCLUDES:*
-- /react-auth-start: express server with auth and todo routes. Assumes prior knowledge of backend user authentication. Contains a wireframe front-end interface with react-router and redux from which to start implementing a user authentication feature.
+**INCLUDES:**
+* All the server-side project code with JWT authentication set up as found in [part 1 of the authentication series](https://coursework.vschool.io/token-auth-with-jwts-part1/)
+* The boilerplate React code for a simple todo project with sign in and sign up routes
 
-- /react-auth-complete: finished project
-
-***To USE***
+**To USE**
 
 - `git clone https://github.com/VSchool/react-auth-series.git`
-- *you can view completed project in /react-auth-complete*
 - from within /react-auth-start, install server dependencies: `npm install`
 - run server: `nodemon index.js`
 - `cd client`

--- a/client/src/main/routes/todos/AddTodoForm.js
+++ b/client/src/main/routes/todos/AddTodoForm.js
@@ -19,4 +19,4 @@ function AddTodoForm(props) {
     )
 }
 
-export default AddTodoForm
+export default AddTodoForm;

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    secret: "correct horse battery staple"
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,45 +1,31 @@
 const express = require("express");
+const app = express();
+const morgan = require("morgan");
 const mongoose = require("mongoose");
 const bodyParser = require("body-parser");
-const morgan = require("morgan");
-const path = require("path");
 const cors = require("cors");
+const expressJwt = require("express-jwt");
+const PORT = process.env.PORT || 5000;
 
-//import routes
-const todoRouter = require("./routes/todo.js");
-const authRouter = require("./routes/auth.js");
-const profileRoute = require("./routes/profile.js");
+app.use(morgan("dev"));
+app.use(bodyParser.json());
+app.use(cors());
 
 //connect to db
 mongoose.Promise = global.Promise;
 mongoose.connect("mongodb://localhost/todo-auth-example",
-    {useMongoClient: true},
-    err => {
+    {useMongoClient: true},  // helps get rid of deprecation warnings
+    (err) => {
         if (err) throw err;
         console.log("Connected to the database");
-    });
+    }
+);
 
-//base express app
-const app = express();
+app.use("/api", expressJwt({secret: config.secret}));
+app.use("/api/todo", require("./routes/todo.js"));
+app.use("/api/profile", require("./routes/profile.js"));
 
-//setup cors
-app.use(cors());
-
-//setup JSON requests
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-
-//use routes
-app.use("/todo", todoRouter);
-app.use("/auth", authRouter);  
-app.use("/profile", profileRoute);
-
-//setup logging
-app.use(morgan("dev"));
-
-//setup routes
-
-const PORT = process.env.PORT || 5000;
+app.use("/auth", require("./routes/auth.js"));
 
 app.listen(PORT, () => {
     console.log(`[+] Starting server on port ${PORT}`);

--- a/server/models/todo.js
+++ b/server/models/todo.js
@@ -1,7 +1,7 @@
-let mongoose = require("mongoose");  
-let Schema = mongoose.Schema;
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
 
-let todoSchema = new Schema({  
+const todoSchema = new Schema({
     title: {
         type: String,
         required: true

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,9 +1,7 @@
-let mongoose = require("mongoose");
-let Schema = mongoose.Schema;
-let bcrypt = require("bcrypt");
-let salt = bcrypt.genSaltSync(10);
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
 
-let userSchema = new Schema({
+const userSchema = new Schema({
     name: String,
     username: {
         type: String,
@@ -21,26 +19,4 @@ let userSchema = new Schema({
     }
 });
 
-//Note you must use `function` here because
-//you are referring to the this of the userSchema
-userSchema.pre("save", function (next) {
-    this.password = bcrypt.hashSync(this.password, salt)
-    next();
-});
-userSchema.methods.withoutPassword = function () {
-    let user = this.toObject();
-    delete user.password;
-    return user;
-};
-userSchema.methods.auth = function (passwordAttempt, cb) {
-    bcrypt.compare(passwordAttempt, this.password, (err, isMatch) => {
-        if (err) {
-            console.log(err);
-            cb(false);
-        } else {
-            cb(isMatch);
-        }
-    });
-};
-
-module.exports = mongoose.model("User", userSchema); 
+module.exports = mongoose.model("User", userSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -18,8 +18,6 @@
     "jsonwebtoken": "^8.0.1",
     "mongoose": "^4.11.12",
     "morgan": "^1.8.2",
-    "nodemon": "^1.12.1",
-    "passport": "^0.4.0",
-    "passport-local": "^1.0.0"
+    "nodemon": "^1.12.1"
   }
 }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,105 +1,31 @@
-let express = require("express");
-let passport = require("passport");
-let Strategy = require("passport-local");
-let jwt = require("jsonwebtoken");
-
-let settings = require("../settings.js");
-
-//import user model
-let User = require("../models/user.js");
-
+const express = require("express")
+const config = require("../config");
+const User = require("../models/user");
 const authRouter = express.Router();
 
-//passport uses .use because we can have multiple solutions
-passport.use(new Strategy((usernameAttempt, passwordAttempt, done) => {
-    //find the user with the usernameAttempt given 
-    User.findOne({
-        username: usernameAttempt
-    }, (err, currentUser) => {
-        if (err) {
-            //if there is an err pass it to passport and return false for auth 
-            done(err, false);
-        } else if (currentUser === null) {
-            //if there is no user with the username given pass null for error and return false for auth
-            done(null, false);
-        } else {
-            //test if the passwordAttempt hash is the same as the hash stored
-            currentUser.auth(passwordAttempt, (isCorrect) => {
-                //pass null for the error and return whether the password was correct for auth
-                done(null, isCorrect)
-            });
-        }
-    });
-}));
-
-//startup passport
-authRouter.use(passport.initialize());
-
-//post a new user to user collection
 authRouter.post("/signup", (req, res) => {
-    // try to find a user with the provided username. (If it already exists, we want to tell them
-    // that the username is already taken.)
-    User.findOne({
-        username: req.body.username
-    }, (err, result) => {
-        if (err) {
-            res.status(500).send({
-                success: false,
-                err
-            });
-        } else if (result !== null) {
-            res.status(400).send({
-                success: false,
-                err: "User already exists!"
-            });
-        } else {
-            // If the function reaches this point and hasn't return-ed already, we're safe
-            // to create the new user in the database.
-            let newUser = new User(req.body);
-            newUser.save((err, user) => {
-                if (err) {
-                    res.status(500).send({
-                        success: false,
-                        err
-                    });
-                } else {
-                    res.status(201).send({
-                        success: true,
-                        token: jwt.sign(user.withoutPassword(), settings.secret, {
-                            expiresIn: 30 * 60
-                        }),
-                        user: user.withoutPassword()
-                    });
-                }
-            });
+    User.findOne({username: req.body.username}, (err, result) => {
+        if (err) return res.status(500).send({success: false, err});
+        if (result !== null) {
+            return res.status(400).send({success: false, err: "That username already exists!"});
         }
+        const newUser = new User(req.body);
+        newUser.save((err, user) => {
+            if (err) return res.status(500).send({success: false, err});
+            return res.status(201).send({success: true, user});
+        });
     });
 });
 
-//set false for session because we are doing token auth
-authRouter.post("/login", passport.authenticate("local", { session: false }), (req, res) => {
-    //we get here once the user is authenticated
-    //find the user so we can send its info
-    User.findOne({
-        username: req.body.username
-    }, (err, user) => {
-        if (err) {
-            res.status(500).send({ "message": "Error", err });
-        } else if (user === null) {
-            res.status(404).send({ "message": "No user found with this username" });
-        } else {
-            //if there was no error issue
-            //a token with the payload begin the user object minus the password
-            //We have also added an expiration time of 30 minutes
-            res.status(201).send({
-                success: true,
-                token: jwt.sign(user.withoutPassword(), settings.secret, {
-                    expiresIn: 30 * 60
-                }),
-                user: user.withoutPassword()
-            });
+authRouter.post("/login", (req, res) => {
+    User.findOne({username: req.body.username.toLowerCase()}, (err, user) => {
+        if (err) return res.status(500).send(err);
+        if (!user || user.password !== req.body.password) {
+            return res.status(403).send({success: false, message: "Email or password are incorrect"})
         }
-    })
+        const token = jwt.sign(user.toObject(), config.secret, {expiresIn: "24h"});
+        return res.send({token: token, user: user.toObject(), success: true, message: "Here's your token!"})
+    });
 });
 
-module.exports = authRouter; 
+module.exports = authRouter;

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -1,6 +1,6 @@
 let express = require("express");
 let expressJwt = require("express-jwt");
-let settings = require("../settings.js");
+let settings = require("../config.js");
 let User = require("../models/user.js");
 
 let profileRoute = express.Router();

--- a/server/routes/todo.js
+++ b/server/routes/todo.js
@@ -1,49 +1,48 @@
-let express = require("express");
-let Todo = require("../models/todo");
-let expressJwt = require("express-jwt");
-let settings = require("../settings.js");
-
-let auth = expressJwt({ secret: settings.secret });
-
+const express = require("express");
 const todoRouter = express.Router();
-todoRouter.use(auth);
+const Todo = require("../models/todo");
 
-todoRouter.route("/")
-    .get((req, res) => {
-        Todo.find({user: req.user._id}, (err, todos) => {
-            if (err) return res.status(500).send(err);
-            return res.status(200).send(todos);
-        });
-    })
-    .post((req, res) => {
-        let todo = new Todo(req.body);
-        todo.user = req.user._id;
-        todo.save((err, newTodo) => {
-            if (err) return res.status(500).send(err);
-            return res.status(201).send(newTodo);
-        })
+todoRouter.get("/", (req, res) => {
+    Todo.find({user: req.user._id}, (err, todos) => {
+        if (err) return res.status(500).send(err);
+        return res.send(todos);
     });
+});
 
-todoRouter.route("/:todoId")
-    .get((req, res) => {
-        Todo.findOne({ user: req.user._id, _id: req.params.todoId }, (err, todo) => {
-            if (err) return res.status(500).send(err);
-            if (!todo) return res.status(404).send("No todo item found.");
-            return res.status(200).send(todo);
-        });
-    })
-    .put((req, res) => {
-        Todo.findOneAndUpdate({user: req.user._id,_id: req.params.todoId}, req.body, { new: true }, (err, todo) => {
-            if (err) return res.status(500).send(err);
-            return res.status(200).send(todo);
-        });
-    })
-    .delete((req, res) => {
-        Todo.findOneAndRemove({user: req.user._id,_id: req.params.todoId },
-            (err, todo) => {
-                if (err) return res.status(500).send(err);
-                return res.status(200).send(todo);
-            })
+todoRouter.post("/", (req, res) => {
+    const todo = new Todo(req.body);
+    todo.user = req.user;
+    todo.save(function (err, newTodo) {
+        if (err) return res.status(500).send(err);
+        return res.status(201).send(newTodo);
     });
+});
 
-module.exports = todoRouter; 
+todoRouter.get("/:todoId", (req, res) => {
+    Todo.findOne({_id: req.params.todoId, user: req.user._id}, (err, todo) => {
+        if (err) return res.status(500).send(err);
+        if (!todo) return res.status(404).send("No todo item found.");
+        return res.send(todo);
+    });
+});
+
+todoRouter.put("/:todoId", (req, res) => {
+    Todo.findOneAndUpdate(
+        {_id: req.params.todoId,user: req.user._id},
+        req.body,
+        {new: true},
+        (err, todo) => {
+            if (err) return res.status(500).send(err);
+            return res.send(todo);
+        }
+    );
+});
+
+todoRouter.delete("/:todoId", (req, res) => {
+    Todo.findOneAndRemove({_id: req.params.todoId, user: req.user._id}, (err, todo) => {
+        if (err) return res.status(500).send(err);
+        return res.send(todo);
+    });
+});
+
+module.exports = todoRouter;

--- a/server/settings.js
+++ b/server/settings.js
@@ -1,3 +1,0 @@
-module.exports = {  
-    secret: "this should be changed when you go into production"
-  }


### PR DESCRIPTION
Using express-jwt is plenty for JWT auth. Passport will be a good addition when we also introduce Facebook/Google/Twitter auth, but when we do we'll probably want to use the `passport-jwt` strategy instead of `passport-local`.

I also removed all references to password hashing, because we're going to introduce that after we get the basics running in Express.